### PR TITLE
Dependencia adicional

### DIFF
--- a/conhecendo-projeto-workshop/pom.xml
+++ b/conhecendo-projeto-workshop/pom.xml
@@ -25,6 +25,17 @@
 			<version>2.2.1.Final</version>
 			<scope>compile</scope>
 		</dependency>
+		
+		<!-- 
+		    Weld requiere esta dependencia
+		    de lo contrario Tomcat 8.0.20 no inicia 
+		-->
+		<dependency>
+	                <groupId>org.jboss</groupId>
+	                <artifactId>jandex</artifactId>
+   	                <version>1.2.3.Final</version>
+                </dependency>
+
 
 		<dependency>
 			<groupId>org.hibernate</groupId>


### PR DESCRIPTION
Estuve bastante tiempo intentando descubrir la razón por la que Tomcat 8.0.20 no iniciaba. Luego de agregar jandex como dependencia explícitamente, todo volvió a funcionar. Esto es usando Weld 2.2.9.
Creo que puede ahorrar dolor de cabeza a otros.
